### PR TITLE
handle go versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ bindown template-source add semver-select https://github.com/WillAbides/semver-s
 bindown dependency add semver-select --source semver-select -y
 ```
 
+## Usage
+
 <!--- start usage output --->
 
 ```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Flags:
   -n, --max-results=INT        maximum number of results to output
   -i, --ignore-invalid         ignore invalid candidates instead of erroring
       --validate-constraint    just validate the constraint. exits non-zero if invalid
+      --go                     allow go-style versions for candidates (e.g. 1.15rc1 or go1.20)
 ```
 
 <!--- end usage output --->

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ bindown dependency add semver-select --source semver-select -y
 <!--- start usage output --->
 
 ```
-Usage: semver-select --constraint=STRING <candidates> ...
+Usage: semver-select --constraint=STRING [<candidates> ...]
 
 semver-select selects matching semvers from a list.
 
@@ -26,7 +26,7 @@ For example, get the newest version of go 1.15 like so:
       | semver-select -i -c '1.15' -
 
 Arguments:
-  <candidates> ...    candidate versions to consider -- value of "-" indicates stdin
+  [<candidates> ...]    candidate versions to consider -- value of "-" indicates stdin
 
 Flags:
   -h, --help                   Show context-sensitive help.

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,11 @@ go 1.21
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/alecthomas/kong v0.8.0
+	github.com/stretchr/testify v1.8.4
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,15 @@ github.com/alecthomas/kong v0.8.0 h1:ryDCzutfIqJPnNn0omnrgHLbAggDQM2VWHikE1xqK7s
 github.com/alecthomas/kong v0.8.0/go.mod h1:n1iCIO2xS46oE8ZfYCNDqdR0b0wZNrXAIAqro/2132U=
 github.com/alecthomas/repr v0.1.0 h1:ENn2e1+J3k09gyj2shc0dHr/yjaWSHRlrJ4DPMevDqE=
 github.com/alecthomas/repr v0.1.0/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/semver-select_test.go
+++ b/semver-select_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/stretchr/testify/assert"
+)
+
+func newBuffer(lines []string) io.Reader {
+	return strings.NewReader(strings.Join(lines, "\n"))
+}
+
+func Test_run(t *testing.T) {
+	for _, td := range []struct {
+		name     string
+		args     []string
+		stdin    io.Reader
+		want     []string
+		wantExit int
+		wantErr  string
+	}{
+		{
+			name: `validate "1.x"`,
+			args: []string{"--validate-constraint", "-c", "1.x"},
+		},
+		{
+			name:     `validate "1.invalid"`,
+			args:     []string{"--validate-constraint", "-c", "1.invalid"},
+			wantErr:  `invalid constraint: "1.invalid"`,
+			wantExit: 1,
+		},
+		{
+			name: "matches exact version",
+			args: []string{"-c", "1.2.3", "1.2.0", "1.2.3-rc1", "1.2.3", "1.2.4"},
+			want: []string{"1.2.3"},
+		},
+		{
+			name: "outputs canonical version",
+			args: []string{"-c", "1", "1.2", "1", "1.2.3", "1.2.4"},
+			want: []string{"1.2.4", "1.2.3", "1.2.0", "1.0.0"},
+		},
+		{
+			name: "honors --max-results",
+			args: []string{"-c", "1", "--max-results", "2", "1.2", "1", "1.2.3", "1.2.4"},
+			want: []string{"1.2.4", "1.2.3"},
+		},
+		{
+			name:     "errors on invalid candidate",
+			args:     []string{"-c", "1.2.3", "1.2.0", "1.2.3-rc1", "1.2.3", "1.2.4", "invalid"},
+			wantExit: 1,
+			wantErr:  `could not parse version "invalid": Invalid Semantic Version`,
+		},
+		{
+			name: "ignores invalid candidate with --ignore-invalid",
+			args: []string{"-c", "1.2.3", "--ignore-invalid", "1.2.0", "1.2.3-rc1", "1.2.3", "1.2.4", "invalid"},
+			want: []string{"1.2.3"},
+		},
+		{
+			name:     "errors on no candidates",
+			args:     []string{"-c", "1.2.3"},
+			wantExit: 1,
+			wantErr:  "no candidates provided",
+		},
+		{
+			name:  "accepts stdin",
+			args:  []string{"-c", "1.2.3", "-"},
+			stdin: newBuffer([]string{"1.2.0", "1.2.3-rc1", "1.2.3", "1.2.4"}),
+			want:  []string{"1.2.3"},
+		},
+	} {
+		t.Run(td.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			exitVal := 0
+			var cli rootCmd
+			parser := kong.Must(
+				&cli,
+				kong.Name("semver-select"),
+				kong.Vars{"version": version},
+				kong.Description(strings.TrimSpace(description)),
+				kong.Writers(&stdout, &stderr),
+				kong.Exit(func(i int) { exitVal = i }),
+			)
+			run(parser, &cli, td.stdin, td.args)
+			assert.Equal(t, td.wantExit, exitVal, "exit value")
+			assert.Equal(
+				t,
+				td.wantErr,
+				strings.TrimPrefix(strings.TrimSpace(stderr.String()), "semver-select: error: "),
+				"stderr",
+			)
+			gotOut := strings.TrimSpace(stdout.String())
+			if len(td.want) == 0 {
+				assert.Equal(t, "", gotOut, "stdout")
+			} else {
+				got := strings.Split(gotOut, "\n")
+				assert.Equal(t, td.want, got, "stdout")
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds a `--go` flag that allows candidates to be formatted as go releases instead of valid semver.